### PR TITLE
fix: subtitle fontsize in mobile

### DIFF
--- a/src/components/Body.jsx
+++ b/src/components/Body.jsx
@@ -17,7 +17,7 @@ function HeroHeader({ selectedLang, isCompact = false }) {
     const { t } = useTranslation();
 
     // Adjust font sizes based on compact mode
-    const titleFontSize = isCompact ? '20px' : '3vw';
+    const titleFontSize = isCompact ? '20px' : '2.5vw';
     const subtitleFontSize = isCompact ? '1.5vw' : '2vw';
     const marginBottom = isCompact ? '2vw' : '-2vw';
     const marginTop = isCompact ? '1vw' : '0vw';


### PR DESCRIPTION
<img width="431" height="876" alt="image" src="https://github.com/user-attachments/assets/87fa05ea-2d0d-4aa6-b78b-b89c2080d15a" />
<img width="430" height="899" alt="image" src="https://github.com/user-attachments/assets/32315e7d-79cc-4adc-bb12-e60aae88098a" />
